### PR TITLE
[fix] Fixed Grafana deployment upgrade

### DIFF
--- a/helms/odahu-flow-monitoring/values.yaml
+++ b/helms/odahu-flow-monitoring/values.yaml
@@ -409,7 +409,8 @@ odahuflow-grafana:
   fullnameOverride: grafana
   image:
     tag: 6.4.4
-
+  deploymentStrategy:
+    type: Recreate
   adminUser: grafana_admin
   adminPassword: grafana_password
   resources:


### PR DESCRIPTION
With default RollingUpdate strategy, the new pod can't be deployed because the PV
is mount to the old pod.