### PR TITLE
[#243] Upgrading knative to 0.17.0 version, enabling pod feature flags

### DIFF
--- a/helms/odahu-flow-knative/crds/knativeeventings.yaml
+++ b/helms/odahu-flow-knative/crds/knativeeventings.yaml
@@ -58,6 +58,19 @@ spec:
         spec:
           description: Spec defines the desired state of KnativeEventing
           properties:
+            version:
+              description: The version of Knative Eventing to be installed
+              type: string
+            manifests:
+              description: A list of eventing manifests, which will be installed by
+                the operator
+              type: array
+              items:
+                type: object
+                properties:
+                  URL:
+                    description: The link of the manifest URL
+                    type: string
             config:
               additionalProperties:
                 additionalProperties:
@@ -94,7 +107,7 @@ spec:
                         type: string
             defaultBrokerClass:
               description: The default broker type to use for the brokers Knative
-                creates. If no value is provided, ChannelBasedBroker will be used.
+                creates. If no value is provided, MTChannelBasedBroker will be used.
               type: string
             resources:
               description: A mapping of deployment name to resource requirements
@@ -135,9 +148,19 @@ spec:
                       ephemeral-storage:
                         type: string
                         pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
+            sinkBindingSelectionMode:
+              description: Specifies the selection mode for the sinkbinding webhook.
+                If the value is `inclusion`, only namespaces/objects labelled as `bindings.knative.dev/include:true`
+                will be considered. If `exclusion` is selected, only `bindings.knative.dev/exclude:true`
+                label is checked and these will NOT be considered. The default is
+                `exclusion`.
+              type: string
           type: object
         status:
           properties:
+            observedGeneration:
+              description: The generation last processed by the controller
+              type: integer
             conditions:
               description: The latest available observations of a resource's current
                 state.
@@ -174,6 +197,12 @@ spec:
             version:
               description: The version of the installed release
               type: string
+            manifests:
+              description: The list of eventing manifests, which have been installed
+                by the operator
+              type: array
+              items:
+                type: string
           type: object
   version: v1alpha1
   versions:

--- a/helms/odahu-flow-knative/crds/knativeservings.yaml
+++ b/helms/odahu-flow-knative/crds/knativeservings.yaml
@@ -58,6 +58,19 @@ spec:
         spec:
           description: Spec defines the desired state of KnativeServing
           properties:
+            version:
+              description: The version of Knative Serving to be installed
+              type: string
+            manifests:
+              description: A list of serving manifests, which will be installed by
+                the operator
+              type: array
+              items:
+                type: object
+                properties:
+                  URL:
+                    description: The link of the manifest URL
+                    type: string
             config:
               additionalProperties:
                 additionalProperties:
@@ -177,6 +190,9 @@ spec:
         status:
           description: Status defines the observed state of KnativeServing
           properties:
+            observedGeneration:
+              description: The generation last processed by the controller
+              type: integer
             conditions:
               description: The latest available observations of a resource's current
                 state.
@@ -213,6 +229,12 @@ spec:
             version:
               description: The version of the installed release
               type: string
+            manifests:
+              description: The list of serving manifests, which have been installed
+                by the operator
+              type: array
+              items:
+                type: string
           type: object
   version: v1alpha1
   versions:

--- a/helms/odahu-flow-knative/templates/knative-operator/configmaps.yaml
+++ b/helms/odahu-flow-knative/templates/knative-operator/configmaps.yaml
@@ -43,10 +43,10 @@ metadata:
     app: {{ template "knative-operator.name" . }}-operator
     {{- include "knative-operator.labels" . | indent 4 }}
 
-    {{- if .Values.knativeOperator.config.features }}
-    data:
-      {{- toYaml .Values.knativeOperator.config.features | nindent 6 }}
+  {{- if .Values.knativeOperator.config.features }}
+  data:
+    {{- toYaml .Values.knativeOperator.config.features | nindent 6 }}
 
-    {{- else }}
-    data: {}
-    {{- end }}
+  {{- else }}
+  data: {}
+  {{- end }}

--- a/helms/odahu-flow-knative/templates/knative-operator/configmaps.yaml
+++ b/helms/odahu-flow-knative/templates/knative-operator/configmaps.yaml
@@ -40,12 +40,12 @@ metadata:
   namespace: {{ template "knative-operator.namespace" . }}
   labels:
     serving.knative.dev/release: "v0.17.0"
-    app: { { template "knative-operator.name" . } }-operator
+    app: {{ template "knative-operator.name" . }}-operator
     {{- include "knative-operator.labels" . | indent 4 }}
 
     {{- if .Values.knativeOperator.config.features }}
     data:
-    {{- toYaml .Values.knativeOperator.config.features | nindent 6 }}
+      {{- toYaml .Values.knativeOperator.config.features | nindent 6 }}
 
     {{- else }}
     data: {}

--- a/helms/odahu-flow-knative/templates/knative-operator/configmaps.yaml
+++ b/helms/odahu-flow-knative/templates/knative-operator/configmaps.yaml
@@ -31,3 +31,22 @@ data:
 {{- else }}
 data: {}
 {{- end }}
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-features
+  namespace: {{ template "knative-operator.namespace" . }}
+  labels:
+    serving.knative.dev/release: "v0.17.0"
+    app: { { template "knative-operator.name" . } }-operator
+    {{- include "knative-operator.labels" . | indent 4 }}
+
+    {{- if .Values.knativeOperator.config.features }}
+    data:
+    {{- toYaml .Values.knativeOperator.config.features | nindent 6 }}
+
+    {{- else }}
+    data: {}
+    {{- end }}

--- a/helms/odahu-flow-knative/templates/knative-operator/configmaps.yaml
+++ b/helms/odahu-flow-knative/templates/knative-operator/configmaps.yaml
@@ -44,7 +44,7 @@ metadata:
     {{- include "knative-operator.labels" . | indent 4 }}
 {{- if .Values.knativeOperator.config.features }}
 data:
-  {{- toYaml .Values.knativeOperator.config.features | nindent 6 }}
+  {{- toYaml .Values.knativeOperator.config.features | nindent 2 }}
 {{- else }}
 data: {}
 {{- end }}

--- a/helms/odahu-flow-knative/templates/knative-operator/configmaps.yaml
+++ b/helms/odahu-flow-knative/templates/knative-operator/configmaps.yaml
@@ -42,11 +42,9 @@ metadata:
     serving.knative.dev/release: "v0.17.0"
     app: {{ template "knative-operator.name" . }}-operator
     {{- include "knative-operator.labels" . | indent 4 }}
-
-  {{- if .Values.knativeOperator.config.features }}
-  data:
-    {{- toYaml .Values.knativeOperator.config.features | nindent 6 }}
-
-  {{- else }}
-  data: {}
-  {{- end }}
+{{- if .Values.knativeOperator.config.features }}
+data:
+  {{- toYaml .Values.knativeOperator.config.features | nindent 6 }}
+{{- else }}
+data: {}
+{{- end }}

--- a/helms/odahu-flow-knative/values.yaml
+++ b/helms/odahu-flow-knative/values.yaml
@@ -171,6 +171,10 @@ knativeOperator:
       #         "callerEncoder": ""
       #       }
       #     }
+    features:
+      kubernetes.podspec-affinity: "enabled"
+      kubernetes.podspec-nodeselector: "enabled"
+      kubernetes.podspec-tolerations: "enabled"
 
 knative:
   serving:

--- a/helms/odahu-flow-knative/values.yaml
+++ b/helms/odahu-flow-knative/values.yaml
@@ -22,7 +22,7 @@ knativeOperator:
     create: true
 
   # Knative-operator image
-  image: gcr.io/knative-releases/knative.dev/operator/cmd/operator@sha256:e94d8d1c739205b5d5929e5cd49f1e1d4007a76e1aae0a6988ce15f21341819e
+  image: gcr.io/knative-releases/knative.dev/operator/cmd/operator@sha256:17c0b3bce1fc27d7a8d3b37f44f862e6f26a776f03d4a19469440f8dab1d7778
   pullPolicy: IfNotPresent
 
   # Clean up custom resources created by Knative operator


### PR DESCRIPTION
Parent PR: https://github.com/odahu/odahu-flow/pull/334.
Change notes:
- Upgraded knative resources according to this `operator.yaml` from v0.17.0:
https://github.com/knative/operator/releases/download/v0.17.0/operator.yaml
- Hard-coded enabling feature flags that allow client to control nodeSelector, tolerations and affinity of a pod, that Knative creates for configuration.