### PR TITLE
[#9] collect opa logs

### DIFF
--- a/helms/odahu-flow-opa/policies/masker.rego
+++ b/helms/odahu-flow-opa/policies/masker.rego
@@ -7,3 +7,7 @@ mask[{"op": "upsert", "path": "/input/attributes/request/http/headers/x-jwt", "v
 mask[{"op": "upsert", "path": "/input/attributes/request/http/headers/cookie", "value": x}] {
   x := "**REDACTED**"
 }
+
+mask[{"op": "upsert", "path": "/input/attributes/request/http/headers/authorization", "value": x}] {
+  x := "**REDACTED**"
+}

--- a/helms/odahu-flow-opa/policies/masker.rego
+++ b/helms/odahu-flow-opa/policies/masker.rego
@@ -1,0 +1,9 @@
+package system.log
+
+mask[{"op": "upsert", "path": "/input/attributes/request/http/headers/x-jwt", "value": x}] {
+  x := "**REDACTED**"
+}
+
+mask[{"op": "upsert", "path": "/input/attributes/request/http/headers/cookie", "value": x}] {
+  x := "**REDACTED**"
+}

--- a/helms/odahu-flow-opa/templates/filter.yaml
+++ b/helms/odahu-flow-opa/templates/filter.yaml
@@ -22,7 +22,7 @@ spec:
             issuer: {{ .Values.authn.oidcIssuer }}
             payload_in_metadata: jwt_payload
             # Forward a JWT to a service
-            forward: true
+            forward: false
             {{- if .Values.authn.localJwks }}
             local_jwks:
               inline_string: '{{ .Values.authn.localJwks }}'

--- a/helms/odahu-flow-opa/values.yaml
+++ b/helms/odahu-flow-opa/values.yaml
@@ -9,7 +9,7 @@ replicaCount: 1
 
 image:
   repository: openpolicyagent/opa
-  tag: 0.16.1-istio-4
+  tag: 0.23.2-istio-2
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
closes #9

- Update openpolicyagent 0.16.1-istio-4 -> 0.23.2-istio-2
- Filter `x-jwt` header and cookie from logs
- Do not forward JWT token from istio 