### PR TITLE
stable charts moved to new location

### DIFF
--- a/helms/odahu-flow-fluentd-daemonset/templates/sa.yaml
+++ b/helms/odahu-flow-fluentd-daemonset/templates/sa.yaml
@@ -4,12 +4,15 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ .Values.serviceAccount.name }}
+{{- if .Values.serviceAccount.annotations }}
+  annotations: {{ toYaml .Values.serviceAccount.annotations | nindent 4 }}
+{{- end }}
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: fluentd
+  name: fluentd-daemonset
 rules:
 - apiGroups:
   - ""
@@ -25,10 +28,10 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
-  name: fluentd
+  name: fluentd-daemonset
 roleRef:
   kind: ClusterRole
-  name: fluentd
+  name: fluentd-daemonset
   apiGroup: rbac.authorization.k8s.io
 subjects:
 - kind: ServiceAccount

--- a/helms/odahu-flow-fluentd-daemonset/values.yaml
+++ b/helms/odahu-flow-fluentd-daemonset/values.yaml
@@ -64,4 +64,5 @@ serviceAccount:
   create: true
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
-  name: fluentd
+  name: fluentd-daemonset
+  annotations: {}

--- a/helms/odahu-flow-fluentd/templates/fluentd/config-values.yaml
+++ b/helms/odahu-flow-fluentd/templates/fluentd/config-values.yaml
@@ -32,6 +32,10 @@ data:
       aws_key_id "#{ENV['AWS_ACCESS_KEY_ID']}"
       aws_sec_key "#{ENV['AWS_SECRET_ACCESS_KEY']}"
       {{- end }}
+      {{- if eq .Values.output.s3.authorization "irsa" }}
+      <web_identity_credentials>
+      </web_identity_credentials>
+      {{- end }}
       {{- if eq .Values.output.s3.authorization "iam" }}
       <instance_profile_credentials>
       </instance_profile_credentials>

--- a/helms/odahu-flow-fluentd/templates/fluentd/server.yaml
+++ b/helms/odahu-flow-fluentd/templates/fluentd/server.yaml
@@ -25,6 +25,9 @@ spec:
       labels:
         {{- include "fluentd.helm-labels" (dict "component" "fluentd" "root" .) | nindent 8 }}
     spec:
+      {{- if .Values.serviceAccount.create }}
+      serviceAccountName: {{ .Values.serviceAccount.name }}
+      {{- end }}
       containers:
       - name: fluentd
         image: "{{ include "fluentd.image-name" (dict "root" . "service" .Values.fluentd "tpl" "%sodahu-flow-fluentd:%s") }}"

--- a/helms/odahu-flow-fluentd/values.yaml
+++ b/helms/odahu-flow-fluentd/values.yaml
@@ -99,6 +99,7 @@ output:
     # - iam - requires kube2iam to be installed in cluster,
     #         adds annotation "iam.amazonaws.com/role" to FluentD Pod
     #         value of annotation could be specified in .feedback.output.s3.customIAMRole
+    # - irsa - use IAM role that attached to k8s service account
     # - secret - provide AWS Key ID and AWS Secret Key in ENV variables for FluentD server
     #            AWS Key ID and AWS Secret Key should be specified in
     #            .feedback.output.s3.AWSKeyID and .feedback.output.s3.AWSSecretKey
@@ -200,3 +201,11 @@ output:
     # Temporary buffering location
     # Type: string
     path: /tmp
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: fluentd
+  annotations: {}

--- a/helms/odahu-flow-monitoring/Chart.yaml
+++ b/helms/odahu-flow-monitoring/Chart.yaml
@@ -8,11 +8,11 @@ dependencies:
   alias: odahuflow-grafana
   version: "5.5.5"
   type: application
-  repository: "https://kubernetes-charts.storage.googleapis.com"
+  repository: "https://charts.helm.sh/stable"
 - name: prometheus-operator
   version: "8.7.0"
   type: application
-  repository: "https://kubernetes-charts.storage.googleapis.com"
+  repository: "https://charts.helm.sh/stable"
 keywords:
 - ML
 maintainers:

--- a/helms/odahu-flow-syncer/templates/syncer/deployment.yaml
+++ b/helms/odahu-flow-syncer/templates/syncer/deployment.yaml
@@ -32,6 +32,9 @@ spec:
         app: {{ template "syncer.fullname" . }}
     spec:
       restartPolicy: Always
+      {{- if .Values.serviceAccount.create }}
+      serviceAccountName: {{ .Values.serviceAccount.name }}
+      {{- end }}
       containers:
         - name: syncer
           image: rclone/rclone:{{ .Values.rclone.version }}

--- a/helms/odahu-flow-syncer/values.yaml
+++ b/helms/odahu-flow-syncer/values.yaml
@@ -57,6 +57,7 @@ sync:
   s3:
     # Type of authorization on S3
     # Valid values are:
+    # - irsa - use IAM role that attached to k8s service account
     # - iam - requires kube2iam to be installed in cluster,
     #         adds annotation "iam.amazonaws.com/role" to FluentD Pod
     #         value of annotation could be specified in .feedback.output.s3.customIAMRole
@@ -94,3 +95,12 @@ sync:
     # Azure Blob container name
     # Type: string
     bucket: ~
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: odahu-syncer
+  annotations: {}
+


### PR DESCRIPTION
https://kubernetes-charts.storage.googleapis.com -> https://charts.helm.sh/stable

see https://helm.sh/blog/new-location-stable-incubator-charts/