### PR TITLE
stable charts moved to new location

### DIFF
--- a/helms/odahu-flow-monitoring/Chart.yaml
+++ b/helms/odahu-flow-monitoring/Chart.yaml
@@ -8,11 +8,11 @@ dependencies:
   alias: odahuflow-grafana
   version: "5.5.5"
   type: application
-  repository: "https://kubernetes-charts.storage.googleapis.com"
+  repository: "https://charts.helm.sh/stable"
 - name: prometheus-operator
   version: "8.7.0"
   type: application
-  repository: "https://kubernetes-charts.storage.googleapis.com"
+  repository: "https://charts.helm.sh/stable"
 keywords:
 - ML
 maintainers:


### PR DESCRIPTION
https://kubernetes-charts.storage.googleapis.com -> https://charts.helm.sh/stable

see https://helm.sh/blog/new-location-stable-incubator-charts/